### PR TITLE
feat: add Product Thinkers page

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -51,6 +51,21 @@ function renderMarkdown(text: string): ReactNode {
 // Changelog entries - newest first
 const CHANGELOG = [
   {
+    version: '0.9.0',
+    date: '2026-02-05',
+    title: 'Product Thinkers',
+    description: 'Added a new section showcasing product thinkers who have shaped my approach to design and product work.',
+    changes: [
+      'Created `/thinkers` page with edge-touching card grid',
+      'Added homepage preview section between Experience and Testimonials',
+      'Features Teresa Torres, Spiek & Moesta, Ryan Singer, and Christopher Alexander',
+      'Created thinkers content data model in `/src/content/thinkers.ts`',
+      'Created reusable `ThinkerCard` component for homepage use',
+    ],
+    aiTools: ['Claude Code'],
+    branch: 'GChainey/product-thinkers-page',
+  },
+  {
     version: '0.8.0',
     date: '2026-02-05',
     title: 'RFP Case Study',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,9 @@ import { MessageCircle, X, ArrowRight } from 'lucide-react'
 import { Header } from '@/components/Header'
 import { ChatInterface } from '@/components/ChatInterface'
 import { GitHubContributions } from '@/components/GitHubContributions'
+import { ThinkerCard } from '@/components/ThinkerCard'
 import { useFeatureFlags } from '@/context/FeatureFlagContext'
+import { thinkers } from '@/content/thinkers'
 
 // Roles that animate
 const ROLES = ['Product Designer', 'Design Engineer', 'Product Manager', 'Engineer']
@@ -370,6 +372,33 @@ export default function Home() {
                       </motion.div>
                     ))}
                   </div>
+                </div>
+              </motion.div>
+            </section>
+
+            {/* Product Thinkers section */}
+            <section className="border-b border-border">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.78 }}
+              >
+                <div className={`flex items-center justify-between px-8 ${flags.sectionTitleBorders ? 'py-4 border-b border-border' : 'pt-8 pb-4'}`}>
+                  <p className="text-xs text-muted uppercase tracking-widest">Product Thinkers</p>
+                  <Link href="/thinkers" className="text-xs text-muted hover:text-accent transition-colors flex items-center gap-1">
+                    View all <ArrowRight className="w-3 h-3" />
+                  </Link>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2">
+                  {thinkers.map((thinker, index) => (
+                    <div
+                      key={thinker.id}
+                      className={`p-5 ${index % 2 === 0 ? 'md:border-r border-border' : ''} ${index < thinkers.length - (thinkers.length % 2 === 0 ? 2 : 1) ? 'border-b border-border' : ''}`}
+                    >
+                      <ThinkerCard thinker={thinker} index={index} />
+                    </div>
+                  ))}
                 </div>
               </motion.div>
             </section>

--- a/src/app/thinkers/page.tsx
+++ b/src/app/thinkers/page.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { MessageCircle, X } from 'lucide-react'
+import { Header } from '@/components/Header'
+import { ChatInterface } from '@/components/ChatInterface'
+import { useFeatureFlags } from '@/context/FeatureFlagContext'
+import { thinkers } from '@/content/thinkers'
+
+const THINKERS_PAGE_CONTEXT = {
+  page: 'Product Thinkers',
+  description: 'Page showcasing the product thinkers who have influenced Gareth\'s approach to design and product work. Features Teresa Torres (Continuous Discovery Habits, Opportunity Solution Trees), Chris Spiek & Bob Moesta (Jobs-to-be-Done, Switch Framework, Forces of Progress), Ryan Singer (Shape Up, shaping, appetite), and Christopher Alexander (A Pattern Language, timeless design principles).',
+  suggestedQuestions: [
+    'Why does Teresa Torres resonate with you?',
+    'How do you use JTBD in your work?',
+    'What\'s Shape Up and why do you like it?',
+  ],
+  followUpQuestions: [
+    'How does Christopher Alexander relate to product?',
+    'What\'s the forces of progress model?',
+    'How do these ideas show up in your projects?',
+    'What books would you recommend?',
+  ],
+}
+
+function getInitials(name: string, initials?: string): string {
+  if (initials) return initials
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+}
+
+export default function ThinkersPage() {
+  const [chatOpen, setChatOpen] = useState(true)
+  const [chatMounted, setChatMounted] = useState(false)
+  const { flags } = useFeatureFlags()
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setChatMounted(true)
+    }, 1500)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-background transition-colors duration-700">
+      <Header showBack />
+
+      <div className="max-w-7xl mx-auto pt-14">
+        <div className="flex min-h-[calc(100vh-56px)]">
+
+          <main className="flex-1 min-w-0 border-x border-border">
+            {/* Header section */}
+            <section className={`p-8 ${flags.sectionTitleBorders ? 'border-b border-border' : ''}`}>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                <p className="text-xs text-muted uppercase tracking-widest mb-4">Influences</p>
+                <h1 className="text-4xl font-medium text-foreground mb-4">Product Thinkers</h1>
+                <p className="text-lg text-muted max-w-2xl">
+                  The people whose ideas have shaped how I think about product, design, and building software.
+                </p>
+              </motion.div>
+            </section>
+
+            {/* Thinkers grid - edge-touching */}
+            <section className="border-b border-border">
+              <div className="grid grid-cols-1 md:grid-cols-2">
+                {thinkers.map((thinker, index) => {
+                  const isOdd = index % 2 === 1
+                  const isLastRow = index >= thinkers.length - (thinkers.length % 2 === 0 ? 2 : 1)
+
+                  return (
+                    <motion.div
+                      key={thinker.id}
+                      className={`p-6 ${!isOdd ? 'md:border-r border-border' : ''} ${!isLastRow ? 'border-b border-border' : ''}`}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.1 }}
+                    >
+                      <div className="flex items-center gap-4 mb-4">
+                        <div className="w-14 h-14 rounded-full bg-border flex items-center justify-center text-foreground font-medium text-lg flex-shrink-0">
+                          {getInitials(thinker.name, thinker.initials)}
+                        </div>
+                        <div>
+                          <h3 className="font-medium text-foreground text-lg">
+                            {thinker.name}
+                          </h3>
+                          <p className="text-sm text-muted">{thinker.role}</p>
+                        </div>
+                      </div>
+
+                      <p className="text-sm text-muted leading-relaxed mb-4">
+                        {thinker.influence}
+                      </p>
+
+                      <div className="flex flex-wrap gap-2">
+                        {thinker.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 text-xs border border-border rounded text-muted"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </motion.div>
+                  )
+                })}
+              </div>
+            </section>
+          </main>
+
+          {/* Chat toggle button */}
+          <AnimatePresence>
+            {chatMounted && !chatOpen && (
+              <motion.button
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                onClick={() => setChatOpen(true)}
+                className="fixed bottom-6 right-6 z-50 p-4 bg-accent text-white rounded-full shadow-lg hover:scale-105 hover:brightness-110 transition-all"
+              >
+                <MessageCircle className="w-6 h-6" />
+              </motion.button>
+            )}
+          </AnimatePresence>
+
+          {/* Chat sidebar */}
+          <AnimatePresence>
+            {chatMounted && chatOpen && (
+              <motion.aside
+                initial={{ width: 0, opacity: 0 }}
+                animate={{ width: 380, opacity: 1 }}
+                exit={{ width: 0, opacity: 0 }}
+                transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+                className="flex-shrink-0 h-[calc(100vh-56px)] sticky top-14 border-r border-border"
+                style={{ minWidth: 0 }}
+              >
+                <div className="relative h-full flex flex-col w-[380px]">
+                  <button
+                    onClick={() => setChatOpen(false)}
+                    className="absolute top-4 right-4 z-10 p-1.5 text-muted hover:text-foreground hover:bg-border/50 rounded transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                  <ChatInterface pageContext={THINKERS_PAGE_CONTEXT} />
+                </div>
+              </motion.aside>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ThinkerCard.tsx
+++ b/src/components/ThinkerCard.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Thinker } from '@/content/thinkers'
+
+interface ThinkerCardProps {
+  thinker: Thinker
+  index?: number
+}
+
+function getInitials(thinker: Thinker): string {
+  if (thinker.initials) return thinker.initials
+  return thinker.name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+}
+
+export function ThinkerCard({ thinker, index = 0 }: ThinkerCardProps) {
+  return (
+    <motion.div
+      className="group"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.1 }}
+    >
+      <div className="flex items-center gap-3 mb-2">
+        <div className="w-10 h-10 rounded-full bg-border flex items-center justify-center text-foreground font-medium text-sm flex-shrink-0">
+          {getInitials(thinker)}
+        </div>
+        <div className="min-w-0">
+          <h3 className="font-medium text-foreground group-hover:text-accent transition-colors text-sm">
+            {thinker.name}
+          </h3>
+          <p className="text-xs text-muted">{thinker.role}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 mt-3">
+        {thinker.tags.map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-0.5 text-xs border border-border rounded text-muted"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </motion.div>
+  )
+}

--- a/src/content/thinkers.ts
+++ b/src/content/thinkers.ts
@@ -1,0 +1,52 @@
+export interface Thinker {
+  id: string
+  name: string
+  role: string
+  initials?: string
+  influence: string
+  tags: string[]
+  link?: string
+}
+
+export const thinkers: Thinker[] = [
+  {
+    id: 'teresa-torres',
+    name: 'Teresa Torres',
+    role: 'Author, Continuous Discovery Habits',
+    influence:
+      'Teresa changed how I think about discovery. Her Opportunity Solution Tree framework gave me a practical way to connect business outcomes to customer needs, and her emphasis on continuous interviewing pushed me to stay close to users rather than relying on assumptions. Her work made discovery feel less like a phase and more like a habit.',
+    tags: ['Product Discovery', 'Opportunity Solution Trees', 'Continuous Discovery'],
+    link: 'https://www.producttalk.org/',
+  },
+  {
+    id: 'spiek-moesta',
+    name: 'Chris Spiek & Bob Moesta',
+    role: 'Jobs-to-be-Done Practitioners',
+    initials: 'CS',
+    influence:
+      'The Switch framework and forces of progress model completely reframed how I understand why people change products. Instead of asking what features users want, I learned to look at the push, pull, anxiety, and habit forces behind every decision. Their interview techniques are some of the most useful tools in my kit.',
+    tags: ['Jobs-to-be-Done', 'Switch Framework', 'Forces of Progress'],
+    link: 'https://www.rewired.com/',
+  },
+  {
+    id: 'ryan-singer',
+    name: 'Ryan Singer',
+    role: 'Author, Shape Up',
+    influence:
+      'Shape Up gave me a vocabulary for the tension between too much upfront design and too little structure. The concepts of appetite, breadboarding, and fat marker sketches changed how I scope work and communicate with engineers. Ryan showed me that good process is about setting boundaries, not writing specs.',
+    tags: ['Shape Up', 'Shaping', 'Product Strategy'],
+    link: 'https://basecamp.com/shapeup',
+  },
+  {
+    id: 'christopher-alexander',
+    name: 'Christopher Alexander',
+    role: 'Architect & Design Theorist',
+    influence:
+      'Alexander\'s idea that good design comes from patterns — solutions that emerge from real human needs — resonated deeply with how I approach product work. A Pattern Language showed me that the best designs feel inevitable because they\'re rooted in how people actually live and work. His thinking bridges architecture, software, and product in a way that keeps me grounded.',
+    tags: ['A Pattern Language', 'Design Patterns', 'Timeless Design'],
+  },
+]
+
+export function getThinkerById(id: string): Thinker | undefined {
+  return thinkers.find((t) => t.id === id)
+}


### PR DESCRIPTION
## Summary
- New `/thinkers` page with edge-touching card grid showcasing Teresa Torres, Spiek & Moesta, Ryan Singer, and Christopher Alexander
- Homepage preview section between Experience and Testimonials with "View all →" link
- Gareth LLM chat sidebar open by default with thinker-specific context and suggested questions

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)