### PR TITLE
feat: interactive CV page with LLM chat

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -51,6 +51,22 @@ function renderMarkdown(text: string): ReactNode {
 // Changelog entries - newest first
 const CHANGELOG = [
   {
+    version: '1.3.0',
+    date: '2026-02-05',
+    title: 'Interactive CV Page with LLM Chat',
+    description: 'Added a dedicated CV page with rich content, PDF download, and an AI chat sidebar for exploring career details in depth.',
+    changes: [
+      'Created /cv route with structured CV content (experience, skills, education, testimonials)',
+      'Added CV-specific LLM chat context for detailed career Q&A',
+      'CV content data file at src/content/cv.ts acts as a simple CMS',
+      'PDF download button preserved on the page for traditional CV access',
+      'Updated Header nav to link to /cv page instead of raw PDF',
+      'Chat sidebar opens by default with CV-focused suggested questions',
+    ],
+    aiTools: ['Claude Code'],
+    branch: 'GChainey/interactive-cv-page',
+  },
+  {
     version: '1.2.0',
     date: '2026-02-05',
     title: 'Contact Page',

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { MessageCircle, X, Download } from 'lucide-react'
+import { Header } from '@/components/Header'
+import { ChatInterface } from '@/components/ChatInterface'
+import { useFeatureFlags } from '@/context/FeatureFlagContext'
+import { cvData } from '@/content/cv'
+
+const CV_PAGE_CONTEXT = {
+  page: 'CV',
+  description: cvData.llmContext,
+  suggestedQuestions: [
+    "What's your biggest achievement?",
+    "How do you work with engineers?",
+    "Tell me about your AI transformation",
+  ],
+  followUpQuestions: [
+    "What was your impact at SEEK?",
+    "How do you approach user research?",
+    "What's your technical stack?",
+    "Tell me about your design philosophy",
+    "What frameworks do you use?",
+  ],
+}
+
+export default function CVPage() {
+  const [chatOpen, setChatOpen] = useState(true)
+  const { flags } = useFeatureFlags()
+
+  return (
+    <div className="min-h-screen bg-background transition-colors duration-700">
+      <Header showBack />
+
+      <div className="max-w-7xl mx-auto pt-14">
+        <div className="flex min-h-[calc(100vh-56px)]">
+
+          <main className="flex-1 min-w-0 border-x border-border">
+            {/* Header section */}
+            <section className={`p-8 ${flags.sectionTitleBorders ? 'border-b border-border' : ''}`}>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                <p className="text-xs text-muted uppercase tracking-widest mb-4">Curriculum Vitae</p>
+                <h1 className="text-4xl font-medium text-foreground mb-4">{cvData.name}</h1>
+                <p className="text-lg text-muted max-w-2xl mb-2">
+                  {cvData.summary}
+                </p>
+                <p className="text-sm text-muted mb-6">{cvData.location}</p>
+                <a
+                  href="/GarethChaineyCV.pdf"
+                  download="GarethChaineyCV.pdf"
+                  className="inline-flex items-center gap-2 px-5 py-2.5 bg-accent text-white text-sm font-medium rounded-full hover:brightness-110 transition-all"
+                >
+                  <Download className="w-4 h-4" />
+                  Download PDF
+                </a>
+              </motion.div>
+            </section>
+
+            {/* Skills section */}
+            <section className="p-8 border-b border-border">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 }}
+              >
+                <p className="text-xs text-muted uppercase tracking-widest mb-6">Skills</p>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {cvData.skills.map((group) => (
+                    <div key={group.category}>
+                      <p className="font-medium text-foreground text-sm mb-2">{group.category}</p>
+                      <div className="flex flex-wrap gap-2">
+                        {group.items.map((item) => (
+                          <span
+                            key={item}
+                            className="px-2 py-0.5 text-xs border border-border rounded text-muted"
+                          >
+                            {item}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            </section>
+
+            {/* Experience section */}
+            <section className="p-8 border-b border-border">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 }}
+              >
+                <p className="text-xs text-muted uppercase tracking-widest mb-6">Experience</p>
+                <div className="relative">
+                  {/* Timeline line */}
+                  <div className="absolute left-[7px] top-2 bottom-2 w-[2px] bg-border" />
+
+                  <div className="space-y-8">
+                    {cvData.experience.map((exp, index) => (
+                      <motion.div
+                        key={exp.id}
+                        className="flex gap-6 relative"
+                        initial={{ opacity: 0, x: -20 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        transition={{ delay: 0.3 + index * 0.1 }}
+                      >
+                        {/* Timeline dot */}
+                        <div className="flex-shrink-0 w-4 h-4 rounded-full bg-foreground border-4 border-background z-10 mt-1" />
+
+                        <div className="flex-1 pb-2">
+                          <div className="flex items-baseline gap-3 mb-1">
+                            <h3 className="font-medium text-foreground">{exp.company}</h3>
+                            <span className="text-xs text-muted">{exp.period}</span>
+                          </div>
+                          <p className="text-sm text-muted mb-1">{exp.role} · {exp.location}</p>
+                          <p className="text-sm text-muted mb-3">{exp.companyDescription}</p>
+                          <ul className="space-y-2">
+                            {exp.highlights.map((highlight, i) => (
+                              <li key={i} className="text-sm text-muted flex gap-2">
+                                <span className="text-foreground/40 flex-shrink-0 mt-1">&#8226;</span>
+                                <span>{highlight}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      </motion.div>
+                    ))}
+                  </div>
+                </div>
+              </motion.div>
+            </section>
+
+            {/* Education section */}
+            <section className="p-8 border-b border-border">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.5 }}
+              >
+                <p className="text-xs text-muted uppercase tracking-widest mb-6">Education</p>
+                <div className="space-y-4">
+                  {cvData.education.map((edu) => (
+                    <div key={edu.id}>
+                      <div className="flex items-baseline gap-3">
+                        <h3 className="font-medium text-foreground text-sm">{edu.title}</h3>
+                        <span className="text-xs text-muted">{edu.year}</span>
+                      </div>
+                      {edu.institution && (
+                        <p className="text-sm text-muted">{edu.institution}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            </section>
+
+            {/* Testimonials section */}
+            <section className="border-b border-border overflow-hidden">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.6 }}
+              >
+                <div className={`px-8 ${flags.sectionTitleBorders ? 'py-4 border-b border-border' : 'pt-8 pb-4'}`}>
+                  <p className="text-xs text-muted uppercase tracking-widest">Kind words from colleagues</p>
+                </div>
+
+                <div className="overflow-x-auto scrollbar-hide scroll-smooth" style={{ scrollSnapType: 'x mandatory' }}>
+                  <div className="flex" style={{ width: `${cvData.testimonials.length * 50}%` }}>
+                    {cvData.testimonials.map((testimonial, index) => (
+                      <motion.div
+                        key={testimonial.name}
+                        className={`flex-shrink-0 p-5 ${index === 0 ? 'pl-8' : ''} ${index < cvData.testimonials.length - 1 ? 'border-r border-border' : ''}`}
+                        style={{ width: `${100 / cvData.testimonials.length}%`, scrollSnapAlign: 'start' }}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.65 + index * 0.1 }}
+                      >
+                        <div className="flex items-center gap-3 mb-3">
+                          <div className="w-10 h-10 rounded-full bg-border flex items-center justify-center text-foreground font-medium text-sm flex-shrink-0">
+                            {testimonial.name.split(' ').map(n => n[0]).join('')}
+                          </div>
+                          <div className="min-w-0">
+                            <p className="font-medium text-foreground text-sm">{testimonial.name}</p>
+                            <p className="text-xs text-muted">{testimonial.role} · {testimonial.company}</p>
+                          </div>
+                        </div>
+                        <p className="text-sm text-muted leading-relaxed">{testimonial.content}</p>
+                      </motion.div>
+                    ))}
+                  </div>
+                </div>
+              </motion.div>
+            </section>
+
+            {/* Footer */}
+            <footer className="p-8 flex items-center justify-between">
+              <p className="text-xs text-muted">&copy; 2025 Gareth Chainey</p>
+              <button
+                onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                className="text-xs text-muted hover:text-foreground transition-colors"
+              >
+                &uarr; Back to top
+              </button>
+            </footer>
+          </main>
+
+          {/* Chat toggle button */}
+          <AnimatePresence>
+            {!chatOpen && (
+              <motion.button
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                onClick={() => setChatOpen(true)}
+                className="fixed bottom-6 right-6 z-50 p-4 bg-accent text-white rounded-full shadow-lg hover:scale-105 hover:brightness-110 transition-all"
+              >
+                <MessageCircle className="w-6 h-6" />
+              </motion.button>
+            )}
+          </AnimatePresence>
+
+          {/* Chat sidebar */}
+          <AnimatePresence>
+            {chatOpen && (
+              <motion.aside
+                initial={false}
+                animate={{ width: 380, opacity: 1 }}
+                exit={{ width: 0, opacity: 0 }}
+                transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+                className="flex-shrink-0 h-[calc(100vh-56px)] sticky top-14 border-r border-border"
+                style={{ minWidth: 0 }}
+              >
+                <div className="relative h-full flex flex-col w-[380px]">
+                  <button
+                    onClick={() => setChatOpen(false)}
+                    className="absolute top-4 right-4 z-10 p-1.5 text-muted hover:text-foreground hover:bg-border/50 rounded transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                  <ChatInterface pageContext={CV_PAGE_CONTEXT} />
+                </div>
+              </motion.aside>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,9 +27,9 @@ export function Header({ showBack }: HeaderProps) {
           )}
         </div>
         <nav className="flex items-center gap-6">
-          <a href="/GarethChaineyCV.pdf" target="_blank" rel="noopener noreferrer" className="text-sm text-muted hover:text-foreground transition-colors">
+          <Link href="/cv" className="text-sm text-muted hover:text-foreground transition-colors">
             CV
-          </a>
+          </Link>
           <Link href="/projects" className="text-sm text-muted hover:text-foreground transition-colors">
             Projects
           </Link>

--- a/src/content/cv.ts
+++ b/src/content/cv.ts
@@ -1,0 +1,235 @@
+export interface CVExperience {
+  id: string
+  company: string
+  role: string
+  location: string
+  period: string
+  companyDescription: string
+  highlights: string[]
+}
+
+export interface CVEducation {
+  id: string
+  title: string
+  institution: string
+  year: string
+}
+
+export interface CVSkillGroup {
+  category: string
+  items: string[]
+}
+
+export interface CVTestimonial {
+  name: string
+  role: string
+  company: string
+  content: string
+}
+
+export interface CVData {
+  name: string
+  title: string
+  summary: string
+  location: string
+  experience: CVExperience[]
+  education: CVEducation[]
+  skills: CVSkillGroup[]
+  testimonials: CVTestimonial[]
+  llmContext: string
+}
+
+export const cvData: CVData = {
+  name: 'Gareth Chainey',
+  title: 'Senior Product Designer',
+  summary:
+    'Product designer with 10+ years experience working with startups and large scale companies in B2C and B2B SaaS. I create high quality prototypes to rapidly experiment, make product decisions and win deals.',
+  location: 'Sydney, Australia',
+
+  experience: [
+    {
+      id: 'enterpriseai',
+      company: 'EnterpriseAI',
+      role: 'Senior Product Designer',
+      location: 'Sydney, Australia',
+      period: 'May 2025 – Present',
+      companyDescription:
+        'EnterpriseAI is building products that solve business problems by leveraging the powers of LLMs. Building two main products: An agentic workflow creation tool for the enterprise, and a government building application platform.',
+      highlights: [
+        'Built high quality prototypes to quickly respond to multi-million dollar RFP deals (would previously require entire teams to do)',
+        'Set up and led customer discovery and acquisition/conversion for products',
+        'Designed LLM integrated prototypes to build an Enterprise ready agentic workflow management tool',
+        'Closely collaborated with product and engineering to continually improve product and product strategy',
+      ],
+    },
+    {
+      id: 'seek',
+      company: 'SEEK',
+      role: 'Senior Product Designer',
+      location: 'Melbourne, Australia',
+      period: 'May 2022 – September 2024',
+      companyDescription:
+        "SEEK is APAC's largest employment marketplace. Led the continuous discovery for a team tasked with the mission to empower candidates to live fulfilling working lives whilst increasing value to SEEK.",
+      highlights: [
+        'Key member of discovery and led the design for an initiative that better connected candidates with education courses, increasing the existing conversion rate by 75% and adding $500,000 in annual revenue',
+        'Led the discovery and design for projects that helped increase organic visits by 25.9% in a single year, resulting in over a million annual visits',
+        'Conducted 100s of customer interviews, experiments, and assumption tests resulting in confident, successful bets to consistently be made that improved customer value and commercially successful',
+        'Led initiative to implement HEART which resulted in long term alignment of customer value and business objectives',
+      ],
+    },
+    {
+      id: 'bestpractice',
+      company: 'Best Practice Software',
+      role: 'Product Designer',
+      location: 'Brisbane, Australia',
+      period: 'Oct 2019 – May 2022',
+      companyDescription:
+        "Best Practice is Australia's largest Practice Management System. Led the design for the new SaaS successor product, and grew a design team to 5 people and worked with 30+ engineers.",
+      highlights: [
+        'Worked with cross-functional teams providing the end-to-end design for domain specific areas like prescribing as well as domain-agnostic areas such as calendar and invoicing',
+        'Started and maintained the design system that was used by an engineering team of 30+ and design team of 5',
+        'Interviewed and hired other designers, provided mentorship, and helped designers improve their craft',
+      ],
+    },
+  ],
+
+  education: [
+    {
+      id: 'continuous-discovery',
+      title: 'Continuous Discovery Masterclass & Continuous Interviewing',
+      institution: 'Product Talk Academy',
+      year: '2022 & 2023',
+    },
+    {
+      id: 'istqb',
+      title: 'ISTQB Foundation Certification',
+      institution: '',
+      year: '2017',
+    },
+    {
+      id: 'bit',
+      title: 'Bachelor of Information Technology',
+      institution: 'Queensland University of Technology',
+      year: '2013',
+    },
+  ],
+
+  skills: [
+    {
+      category: 'Design',
+      items: [
+        'Product Design',
+        'UX Design',
+        'Prototyping',
+        'Design Systems',
+        'User Research',
+        'Interaction Design',
+      ],
+    },
+    {
+      category: 'Technical',
+      items: [
+        'Next.js',
+        'React',
+        'TypeScript',
+        'Tailwind CSS',
+        'Framer Motion',
+        'Vercel',
+        'Git',
+      ],
+    },
+    {
+      category: 'AI Tools',
+      items: [
+        'Claude',
+        'Claude Code',
+        'Cursor',
+        'LLM API Integration',
+      ],
+    },
+    {
+      category: 'Process & Frameworks',
+      items: [
+        'Shape Up',
+        'Jobs-to-be-Done',
+        'Continuous Discovery',
+        'Teresa Torres OST',
+        'HEART Framework',
+        'Rapid Experimentation',
+      ],
+    },
+    {
+      category: 'Leadership',
+      items: [
+        'Hiring',
+        'Mentorship',
+        'Cross-functional Collaboration',
+        'Customer Discovery',
+      ],
+    },
+  ],
+
+  testimonials: [
+    {
+      name: 'Winnie Bamra',
+      role: 'Senior Product Manager',
+      company: 'Ex-SpaceX · SEEK',
+      content:
+        'Gareth is a pleasure to work with and an asset to any team. He is diligent in discovery, passionate about the end user, empathetic, and collaborative in his approach. He is excellent at leading user interviews, enabling the team to collect and extract actionable insights.',
+    },
+    {
+      name: 'Richard Simms',
+      role: 'Principal Product Designer',
+      company: 'SEEK',
+      content:
+        'A talented senior UX designer who can independently drive projects forward. His designs reflected a deep understanding of our users, combined with a mastery of UX principles. Meticulous attention to detail and craft are evident in everything he produces.',
+    },
+    {
+      name: 'Ahmed Hakeem',
+      role: 'Staff Engineer',
+      company: 'SEEK',
+      content:
+        "A developer's best friend. I have many fond memories bouncing ideas around and jamming out features end to end from fake door tests to deployment. At every step Gareth was inquisitive, collaborative and open to thinking on their feet.",
+    },
+    {
+      name: 'David Deville',
+      role: 'Senior Content Designer',
+      company: 'SEEK',
+      content:
+        'Gareth goes above and beyond designing for customer needs. Fast experimentation, elegant designs and constant iteration resulted in products like an AI-powered resume generator that genuinely helped candidates. A positive, creative and likeable teammate.',
+    },
+    {
+      name: 'Henry Vesander',
+      role: 'Chief Product Officer',
+      company: 'Best Practice Software',
+      content:
+        'An outstanding UX/product designer. I hired him to build a cloud-based practice management SaaS. He is a driven individual that can be trusted in getting the job done once given guidance and a brief. I definitely recommend Gareth!',
+    },
+  ],
+
+  llmContext: `Gareth Chainey is a Senior Product Designer based in Sydney, Australia with 10+ years experience across startups and large-scale companies in B2C and B2B SaaS. He creates high quality prototypes to rapidly experiment, make product decisions, and win deals.
+
+CURRENT ROLE - EnterpriseAI (May 2025 - Present, Sydney):
+Gareth works at EnterpriseAI, which builds products solving business problems with LLMs. He builds two main products: an agentic workflow creation tool for the enterprise, and a government building application platform. He single-handedly builds high quality prototypes to respond to multi-million dollar RFP deals — work that would previously require entire teams. He set up and leads customer discovery and acquisition/conversion. He designed LLM-integrated prototypes for an enterprise-ready agentic workflow management tool. He closely collaborates with product and engineering to continually improve product and strategy. He operates as a one-person product team: PM, designer, QA, and engineer — using AI tools like Claude, Claude Code, and Cursor to ship real code rather than just Figma mockups.
+
+PREVIOUS ROLE - SEEK (May 2022 - Sep 2024, Melbourne):
+SEEK is APAC's largest employment marketplace. Gareth led continuous discovery for a team empowering candidates to live fulfilling working lives. Key achievements: Led design for an initiative connecting candidates with education courses, increasing conversion rate by 75% and adding $500,000 in annual revenue. Led discovery and design for projects that increased organic visits by 25.9% in a single year (over a million annual visits). Conducted 100s of customer interviews, experiments, and assumption tests. Led initiative to implement the HEART framework for long-term alignment of customer value and business objectives.
+
+PREVIOUS ROLE - Best Practice Software (Oct 2019 - May 2022, Brisbane):
+Australia's largest Practice Management System. Gareth led design for the new SaaS successor product. He grew a design team to 5 people and worked with 30+ engineers. He provided end-to-end design for domain-specific areas (prescribing) and domain-agnostic areas (calendar, invoicing). He started and maintained the design system used by 30+ engineers and 5 designers. He interviewed, hired, and mentored other designers.
+
+EDUCATION:
+Continuous Discovery Masterclass & Continuous Interviewing (2022 & 2023, Product Talk Academy), ISTQB Foundation Certification (2017), Bachelor of Information Technology (2013, Queensland University of Technology).
+
+DESIGN PHILOSOPHY:
+Gareth uses Shape Up, Jobs-to-be-Done, Teresa Torres Opportunity Solution Trees, and the HEART framework. He believes in no bureaucracy — just do the thing. He favors collaboration over handoff, early team buy-in over late approval, and rapid experimentation over lengthy spec documents. He creates "lite" versions of products for rapid testing and iteration.
+
+TECHNICAL CAPABILITIES:
+Gareth now codes in Next.js, React, and TypeScript with Tailwind CSS and Framer Motion. He deploys on Vercel. He builds real working prototypes with AI assistance — not just mockups. His AI toolkit includes Claude for thinking, Claude Code for building, and Cursor for coding. His technical stack changes frequently — he uses whatever ships fastest.
+
+WHAT COLLEAGUES SAY:
+Winnie Bamra (Senior PM, ex-SpaceX/SEEK): Diligent in discovery, passionate about the end user, excellent at leading user interviews. Richard Simms (Principal Product Designer, SEEK): Independently drives projects forward, meticulous attention to detail and craft. Ahmed Hakeem (Staff Engineer, SEEK): A developer's best friend — inquisitive, collaborative, and open to thinking on their feet. David Deville (Senior Content Designer, SEEK): Goes above and beyond, fast experimentation and elegant designs. Henry Vesander (CPO, Best Practice): Outstanding designer, driven and trustworthy.
+
+KEY PROJECTS:
+He built an enterprise RFP response system single-handedly using AI tools. He created ProductLite, a real-code prototyping methodology. He designed a no-code LLM workflow configurator. He has shipped multiple LLM-powered features including feature flags, chat interfaces, and dynamic workflows.`,
+}


### PR DESCRIPTION
## Summary
- Created `/cv` route with structured CV content (experience, skills, education, testimonials)
- Added CV-specific LLM chat sidebar for detailed career Q&A — opens by default
- CV content data file at `src/content/cv.ts` acts as a simple CMS
- PDF download button on the page for traditional CV access
- Updated Header nav to link to `/cv` page instead of raw PDF
- Added v1.2.0 changelog entry

Closes #24

## Test plan
- [ ] Navigate to `/cv` and verify all sections render correctly
- [ ] Test chat sidebar with suggested questions
- [ ] Verify "Download PDF" button downloads the CV
- [ ] Confirm Header "CV" link navigates to `/cv`
- [ ] Test theme switching on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)