### PR TITLE
Add warmth theme toggle (feature flagged)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,6 +111,44 @@ html.dark.accent-green { --accent: #4ade80; --accent-light: #052e16; }
 html.dark.accent-lime { --accent: #a3e635; --accent-light: #1a2e05; }
 html.dark.accent-yellow { --accent: #facc15; --accent-light: #422006; }
 
+/* Warm mode — light */
+html.warm {
+  --background: #faf6f0;
+  --foreground: #1c1a16;
+  --border: #e3dcd2;
+  --muted: #887f74;
+  --card: #faf6f0;
+  --card-foreground: #1c1a16;
+  --popover: #faf6f0;
+  --popover-foreground: #1c1a16;
+  --primary: #1c1a16;
+  --primary-foreground: #faf6f0;
+  --secondary: #f0ebe3;
+  --secondary-foreground: #1c1a16;
+  --muted-foreground: #887f74;
+  --input: #e3dcd2;
+  --ring: #1c1a16;
+}
+
+/* Warm mode — dark */
+html.dark.warm {
+  --background: #161310;
+  --foreground: #f0ebe2;
+  --border: #2c2720;
+  --muted: #a69d90;
+  --card: #161310;
+  --card-foreground: #f0ebe2;
+  --popover: #161310;
+  --popover-foreground: #f0ebe2;
+  --primary: #f0ebe2;
+  --primary-foreground: #161310;
+  --secondary: #2c2720;
+  --secondary-foreground: #f0ebe2;
+  --muted-foreground: #a69d90;
+  --input: #2c2720;
+  --ring: #ccc5ba;
+}
+
 /* Text selection highlight with accent color */
 ::selection {
   background-color: var(--selection-bg);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var m=localStorage.getItem('theme-mode');var a=localStorage.getItem('theme-accent')||'amber';var d=document.documentElement;d.className=d.className.split(' ').filter(function(c){return!c.startsWith('accent-')}).join(' ');d.classList.add('accent-'+a);if(m==='light'){d.classList.remove('dark')}else if(m==='system'){if(!window.matchMedia('(prefers-color-scheme: dark)').matches){d.classList.remove('dark')}};}catch(e){}})();`,
+            __html: `(function(){try{var m=localStorage.getItem('theme-mode');var a=localStorage.getItem('theme-accent')||'amber';var w=localStorage.getItem('theme-warm');var d=document.documentElement;d.className=d.className.split(' ').filter(function(c){return!c.startsWith('accent-')}).join(' ');d.classList.add('accent-'+a);if(w==='true'){d.classList.add('warm')}else{d.classList.remove('warm')}if(m==='light'){d.classList.remove('dark')}else if(m==='system'){if(!window.matchMedia('(prefers-color-scheme: dark)').matches){d.classList.remove('dark')}};}catch(e){}})();`,
           }}
         />
       </head>

--- a/src/components/FeatureFlagDrawer.tsx
+++ b/src/components/FeatureFlagDrawer.tsx
@@ -131,6 +131,28 @@ export function FeatureFlagDrawer() {
                 </p>
               </div>
 
+              {/* Warmth Toggle */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-foreground">Warmth</p>
+                  <button
+                    onClick={() => setFlag('warmth', !flags.warmth)}
+                    className={`relative w-11 h-6 rounded-full transition-colors ${
+                      flags.warmth ? 'bg-accent' : 'bg-border'
+                    }`}
+                  >
+                    <motion.div
+                      className="absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow"
+                      animate={{ x: flags.warmth ? 20 : 0 }}
+                      transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                    />
+                  </button>
+                </div>
+                <p className="text-xs text-muted">
+                  Show warmth toggle in theme selector
+                </p>
+              </div>
+
               {/* Particle Field Toggle */}
               <div className="space-y-3">
                 <div className="flex items-center justify-between">

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Sun, Moon, Monitor, Check } from 'lucide-react'
+import { Sun, Moon, Monitor, Check, Flame } from 'lucide-react'
 import { useTheme, ACCENT_COLORS } from '@/context/ThemeContext'
+import { useFeatureFlags } from '@/context/FeatureFlagContext'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,7 +12,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 export function ThemeSelector() {
-  const { mode, resolvedMode, accent, setMode, setAccent } = useTheme()
+  const { mode, resolvedMode, accent, warm, setMode, setAccent, toggleWarm } = useTheme()
+  const { flags } = useFeatureFlags()
 
   // Icon for the trigger button based on current resolved mode
   const TriggerIcon = resolvedMode === 'dark' ? Moon : Sun
@@ -53,6 +55,19 @@ export function ThemeSelector() {
           </span>
           {mode === 'dark' && <Check className="w-4 h-4" />}
         </DropdownMenuItem>
+
+        {flags.warmth && (
+          <>
+            <DropdownMenuLabel className="text-xs text-muted-foreground mt-2">Warmth</DropdownMenuLabel>
+            <DropdownMenuItem onSelect={(e) => { e.preventDefault(); toggleWarm() }} className="flex items-center justify-between">
+              <span className="flex items-center gap-2">
+                <Flame className="w-4 h-4" />
+                Warm
+              </span>
+              {warm && <Check className="w-4 h-4" />}
+            </DropdownMenuItem>
+          </>
+        )}
 
         <DropdownMenuLabel className="text-xs text-muted-foreground mt-2">Accent Color</DropdownMenuLabel>
         <div className="grid grid-cols-8 gap-1 p-2">

--- a/src/content/changelog.ts
+++ b/src/content/changelog.ts
@@ -14,6 +14,20 @@ export interface ChangelogEntry {
 // Changelog entries - newest first
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.15.0',
+    date: '2026-02-24',
+    title: 'Warmth Mode',
+    description: 'Added a warmth toggle to the theme selector that shifts the neutral palette to warmer tones, like f.lux for the website.',
+    changes: [
+      'Added warm mode toggle in theme selector dropdown with Flame icon',
+      'Light warm: creamy off-white background and softened text',
+      'Dark warm: warm dark grey background instead of pure black',
+      'Warmth persists via localStorage and applies before hydration to prevent flash',
+    ],
+    aiTools: ['Claude Code'],
+    branch: 'GChainey/add-warmth-theme',
+  },
+  {
     version: '1.14.0',
     date: '2026-02-20',
     title: 'Animated Signature Component',

--- a/src/context/FeatureFlagContext.tsx
+++ b/src/context/FeatureFlagContext.tsx
@@ -11,6 +11,7 @@ interface FeatureFlags {
   signature: boolean
   signatureVariant: SignatureVariant
   signatureSize: number
+  warmth: boolean
 }
 
 interface FeatureFlagContextType {
@@ -27,6 +28,7 @@ const defaultFlags: FeatureFlags = {
   signature: false,
   signatureVariant: 'off',
   signatureSize: 36,
+  warmth: false,
 }
 
 const FeatureFlagContext = createContext<FeatureFlagContextType | undefined>(undefined)

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -29,9 +29,12 @@ interface ThemeContextType {
   mode: Mode
   resolvedMode: ResolvedMode
   accent: AccentColor
+  warm: boolean
   setMode: (mode: Mode) => void
   setAccent: (accent: AccentColor) => void
+  setWarm: (warm: boolean) => void
   toggleMode: () => void
+  toggleWarm: () => void
   mounted: boolean
   // Legacy support
   theme: ResolvedMode
@@ -44,6 +47,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [mode, setModeState] = useState<Mode>('dark')
   const [systemPreference, setSystemPreference] = useState<ResolvedMode>('dark')
   const [accent, setAccentState] = useState<AccentColor>('amber')
+  const [warm, setWarmState] = useState(false)
   const [mounted, setMounted] = useState(false)
 
   // Get resolved mode based on mode setting and system preference
@@ -53,20 +57,24 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setMounted(true)
     const storedMode = localStorage.getItem('theme-mode') as Mode | null
     const storedAccent = localStorage.getItem('theme-accent') as AccentColor | null
+    const storedWarm = localStorage.getItem('theme-warm')
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
 
     // Default to 'dark' if no stored preference (portfolio looks best in dark)
     const initialMode = storedMode || 'dark'
     const initialAccent = storedAccent || 'amber'
+    const initialWarm = storedWarm === 'true'
     const initialSystemPref = prefersDark ? 'dark' : 'light'
 
     setModeState(initialMode)
     setAccentState(initialAccent)
+    setWarmState(initialWarm)
     setSystemPreference(initialSystemPref)
 
     // Apply classes based on resolved mode
     const resolved = initialMode === 'system' ? initialSystemPref : initialMode
     document.documentElement.classList.toggle('dark', resolved === 'dark')
+    document.documentElement.classList.toggle('warm', initialWarm)
     document.documentElement.className = document.documentElement.className
       .split(' ')
       .filter(c => !c.startsWith('accent-'))
@@ -96,6 +104,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, [mode, mounted])
 
+  // Apply warm class when warm changes
+  useEffect(() => {
+    if (mounted) {
+      document.documentElement.classList.toggle('warm', warm)
+      localStorage.setItem('theme-warm', String(warm))
+    }
+  }, [warm, mounted])
+
   useEffect(() => {
     if (mounted) {
       // Remove old accent class and add new one
@@ -110,6 +126,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setMode = (newMode: Mode) => setModeState(newMode)
   const setAccent = (newAccent: AccentColor) => setAccentState(newAccent)
+  const setWarm = (newWarm: boolean) => setWarmState(newWarm)
+  const toggleWarm = () => setWarmState(prev => !prev)
   const toggleMode = () => setModeState(prev => {
     if (prev === 'system') return 'light'
     if (prev === 'light') return 'dark'
@@ -121,9 +139,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       mode,
       resolvedMode,
       accent,
+      warm,
       setMode,
       setAccent,
+      setWarm,
       toggleMode,
+      toggleWarm,
       mounted,
       // Legacy support
       theme: resolvedMode,


### PR DESCRIPTION
## Summary
- Added warmth mode to theme system that shifts neutral colors to warmer tones (f.lux-like effect)
- Light warm: creamy background, softened text for reduced eye strain
- Dark warm: warm dark grey instead of pure black
- Feature is off by default and gated behind 'warmth' feature flag (enable via Cmd+K in dev)

## Changes
- **ThemeContext**: Added `warm` state, `setWarm`/`toggleWarm` methods, localStorage persistence
- **globals.css**: Added CSS overrides for warm light and dark modes
- **ThemeSelector**: Shows warmth toggle between Mode and Accent sections (when flag enabled)
- **FeatureFlagContext**: Added 'warmth' flag (default: false)
- **FeatureFlagDrawer**: Added warmth toggle in dev controls
- **layout.tsx**: Updated anti-flash script to apply warm class on initial load
- **changelog.ts**: Added v1.15.0 entry documenting the feature

## Test Plan
- [ ] Open feature flags (Cmd+K) and enable "Warmth"
- [ ] Toggle warmth in theme selector dropdown
- [ ] Verify light warm: creamy background, softened text
- [ ] Verify dark warm: warm dark grey background, warm off-white text
- [ ] Verify warmth persists across page reloads
- [ ] Verify warmth works independently with all 3 modes (system/light/dark)
- [ ] Verify warmth can be toggled on/off without page flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)