### PR TITLE
Add SEEK Learning case study with funnel diagram

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -8,7 +8,7 @@ import { X, Clock, ArrowRight, RotateCcw, LayoutGrid, FileText } from 'lucide-re
 import { Header } from '@/components/Header'
 import { ChatInterface } from '@/components/ChatInterface'
 import { Facehash } from 'facehash'
-import { CaseStudyContent } from '@/components/CaseStudyContent'
+import { CaseStudyContent, componentRegistry } from '@/components/CaseStudyContent'
 import { TableOfContents } from '@/components/TableOfContents'
 import { FixedTableOfContents } from '@/components/FixedTableOfContents'
 import { ShimmeringText } from '@/components/ui/shimmering-text'
@@ -41,14 +41,14 @@ const TLDR_OPTIONS = [
 ]
 
 function VisualGallery({ blocks }: { blocks: ContentBlock[] }) {
-  const mediaBlocks = blocks.filter(
-    (b): b is ContentBlock & { type: 'image' | 'gif' | 'video' | 'embed' } =>
-      b.type === 'image' || b.type === 'gif' || b.type === 'video' || b.type === 'embed'
+  // Collect visual blocks: media + components (artifacts like FunnelDiagram)
+  const visualBlocks = blocks.filter(
+    b => b.type === 'image' || b.type === 'gif' || b.type === 'video' || b.type === 'embed' || b.type === 'component'
   )
 
-  // Find the heading that precedes each media block for context
-  function getHeadingForMedia(mediaIndex: number): string | null {
-    const originalIndex = blocks.indexOf(mediaBlocks[mediaIndex])
+  // Find the heading that precedes each visual block for context
+  function getHeadingForVisual(visualIndex: number): string | null {
+    const originalIndex = blocks.indexOf(visualBlocks[visualIndex])
     for (let i = originalIndex - 1; i >= 0; i--) {
       if (blocks[i].type === 'heading') {
         return (blocks[i] as { type: 'heading'; content: string }).content
@@ -59,9 +59,38 @@ function VisualGallery({ blocks }: { blocks: ContentBlock[] }) {
 
   return (
     <div className="space-y-8">
-      {mediaBlocks.map((block, index) => {
-        const heading = getHeadingForMedia(index)
-        const aspectRatio = block.aspectRatio || '16/9'
+      {visualBlocks.map((block, index) => {
+        const heading = getHeadingForVisual(index)
+
+        // Component blocks (e.g. FunnelDiagram)
+        if (block.type === 'component') {
+          const Component = componentRegistry[block.componentId]
+          if (!Component) return null
+          return (
+            <motion.div
+              key={index}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.08 }}
+            >
+              {heading && (
+                <p className="text-xs text-muted uppercase tracking-widest mb-2">
+                  {heading}
+                </p>
+              )}
+              <Component {...(block.props || {})} />
+              {block.caption && (
+                <p className="mt-2 text-sm text-muted text-center">
+                  {block.caption}
+                </p>
+              )}
+            </motion.div>
+          )
+        }
+
+        // Media blocks
+        const mediaBlock = block as ContentBlock & { type: 'image' | 'gif' | 'video' | 'embed' }
+        const aspectRatio = mediaBlock.aspectRatio || '16/9'
 
         return (
           <motion.div
@@ -79,33 +108,33 @@ function VisualGallery({ blocks }: { blocks: ContentBlock[] }) {
               className="relative w-full bg-border/30 rounded-lg overflow-hidden"
               style={{ aspectRatio }}
             >
-              {block.type === 'video' ? (
+              {mediaBlock.type === 'video' ? (
                 <video
-                  src={block.src}
+                  src={mediaBlock.src}
                   autoPlay
                   loop
                   muted
                   playsInline
                   className="w-full h-full object-cover"
                 />
-              ) : block.type === 'embed' ? (
+              ) : mediaBlock.type === 'embed' ? (
                 <iframe
-                  src={block.src}
+                  src={mediaBlock.src}
                   className="w-full h-full border-0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                   allowFullScreen
                 />
               ) : (
                 <img
-                  src={block.src}
-                  alt={block.alt || ''}
+                  src={mediaBlock.src}
+                  alt={(mediaBlock as unknown as { alt?: string }).alt || ''}
                   className="w-full h-full object-cover"
                 />
               )}
             </div>
-            {block.caption && (
+            {mediaBlock.caption && (
               <p className="mt-2 text-sm text-muted text-center">
-                {block.caption}
+                {mediaBlock.caption}
               </p>
             )}
           </motion.div>
@@ -306,7 +335,7 @@ Write 2-3 short paragraphs tailored to what a ${tldrLength} would want to know. 
             </header>
 
             {/* View Mode Tabs - only show if project has media */}
-            {project.content.some((b: ContentBlock) => b.type === 'image' || b.type === 'gif' || b.type === 'video' || b.type === 'embed') && (
+            {project.content.some((b: ContentBlock) => b.type === 'image' || b.type === 'gif' || b.type === 'video' || b.type === 'embed' || b.type === 'component') && (
               <div className="flex justify-center py-4 border-b border-border">
                 <div className="flex bg-border/40 rounded-full p-0.5">
                   <button

--- a/src/components/CaseStudyContent.tsx
+++ b/src/components/CaseStudyContent.tsx
@@ -3,6 +3,12 @@
 import { motion } from 'framer-motion'
 import type { ContentBlock } from '@/content/projects'
 import { slugify } from '@/components/TableOfContents'
+import { FunnelDiagram } from '@/components/FunnelDiagram'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const componentRegistry: Record<string, React.ComponentType<any>> = {
+  'funnel-diagram': FunnelDiagram,
+}
 
 interface CaseStudyContentProps {
   blocks: ContentBlock[]
@@ -136,6 +142,24 @@ export function CaseStudyContent({ blocks }: CaseStudyContentProps) {
                 <li key={i}>{item}</li>
               ))}
             </motion.ul>
+          )
+        }
+
+        if (block.type === 'component') {
+          const Component = componentRegistry[block.componentId]
+          if (!Component) return null
+          return (
+            <motion.div
+              key={index}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay }}
+            >
+              <Component {...(block.props || {})} />
+              {block.caption && (
+                <p className="mt-2 text-sm text-muted text-center">{block.caption}</p>
+              )}
+            </motion.div>
           )
         }
 

--- a/src/components/FunnelDiagram.tsx
+++ b/src/components/FunnelDiagram.tsx
@@ -1,0 +1,343 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { motion, useInView } from 'framer-motion'
+
+interface FunnelStage {
+  label: string
+  highlight?: boolean
+  assumption?: string
+}
+
+interface FunnelDiagramProps {
+  title?: string
+  stages: FunnelStage[]
+  caption?: string
+}
+
+const defaultStages: FunnelStage[] = [
+  { label: 'Impressions', highlight: false },
+  { label: 'Find the right course (tabs)', highlight: true, assumption: 'Too much friction to find a course' },
+  { label: 'Select a course', highlight: true, assumption: 'Missing design details' },
+  { label: 'Course information', highlight: false },
+  { label: 'Lead/Link', highlight: true, assumption: 'Too long to make a connection' },
+]
+
+type ThemeKey = 'accent' | 'subtle' | 'minimal' | 'outline'
+
+const themeLabels: Record<ThemeKey, string> = {
+  accent: 'Accent',
+  subtle: 'Subtle',
+  minimal: 'Minimal',
+  outline: 'Outline',
+}
+
+const ease = [0.22, 1, 0.36, 1] as const
+
+export function FunnelDiagram({
+  title = 'MVP release',
+  stages = defaultStages,
+  caption,
+}: FunnelDiagramProps) {
+  const [themeKey, setThemeKey] = useState<ThemeKey>('accent')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isInView = useInView(containerRef, { once: true, margin: '-100px' })
+
+  // Collect stages that have assumptions, alternating sides
+  const assumptionStages = stages
+    .map((stage, i) => ({ stage, index: i }))
+    .filter(({ stage }) => stage.assumption)
+
+  // SVG dimensions
+  const svgWidth = 400
+  const svgHeight = 480
+  const funnelTopWidth = 280
+  const funnelBottomWidth = 100
+  const funnelStartY = 50
+  const stageHeight = 72
+  const stageGap = 4
+  const centerX = svgWidth / 2
+
+  function getStageWidth(index: number): number {
+    const progress = index / (stages.length - 1)
+    return funnelTopWidth - progress * (funnelTopWidth - funnelBottomWidth)
+  }
+
+  function getStageY(index: number): number {
+    return funnelStartY + index * (stageHeight + stageGap)
+  }
+
+  function getStagePath(i: number): string {
+    const topWidth = getStageWidth(i)
+    const bottomWidth = getStageWidth(i + (i < stages.length - 1 ? 1 : 0))
+    const actualBottomWidth = i === stages.length - 1 ? topWidth * 0.7 : bottomWidth
+    const y = getStageY(i)
+
+    const tl = `${centerX - topWidth / 2},${y}`
+    const tr = `${centerX + topWidth / 2},${y}`
+    const br = `${centerX + actualBottomWidth / 2},${y + stageHeight}`
+    const bl = `${centerX - actualBottomWidth / 2},${y + stageHeight}`
+
+    return `M${tl} L${tr} L${br} L${bl} Z`
+  }
+
+  function getStageColors(stage: FunnelStage) {
+    const isHighlight = stage.highlight
+
+    if (themeKey === 'outline') {
+      return {
+        fill: 'none',
+        fillOpacity: 0,
+        stroke: 'var(--foreground)',
+        strokeWidth: 1,
+        strokeOpacity: isHighlight ? 0.6 : 0.15,
+        textFill: 'var(--foreground)',
+        textOpacity: isHighlight ? 0.9 : 0.5,
+      }
+    }
+
+    if (themeKey === 'minimal') {
+      return {
+        fill: 'none',
+        fillOpacity: 0,
+        stroke: isHighlight ? 'var(--accent)' : 'var(--border)',
+        strokeWidth: 1.5,
+        strokeOpacity: isHighlight ? 0.4 : 0.2,
+        textFill: isHighlight ? 'var(--accent)' : 'var(--muted-foreground)',
+        textOpacity: isHighlight ? 0.7 : 0.5,
+      }
+    }
+
+    // accent & subtle
+    if (isHighlight) {
+      return {
+        fill: 'var(--accent)',
+        fillOpacity: 0.15,
+        stroke: 'var(--accent)',
+        strokeWidth: 1,
+        strokeOpacity: 0.3,
+        textFill: 'var(--accent)',
+        textOpacity: 0.8,
+      }
+    }
+
+    return {
+      fill: themeKey === 'subtle' ? 'var(--foreground)' : 'none',
+      fillOpacity: 0.04,
+      stroke: 'var(--foreground)',
+      strokeWidth: 1,
+      strokeOpacity: 0.08,
+      textFill: 'var(--muted-foreground)',
+      textOpacity: 0.6,
+    }
+  }
+
+  // Calculate vertical position as percentage for assumption cards
+  function getStageVerticalPercent(index: number): number {
+    const y = getStageY(index) + stageHeight / 2
+    return (y / svgHeight) * 100
+  }
+
+  return (
+    <figure className="my-10" ref={containerRef}>
+      <div
+        className={`relative w-full rounded-xl overflow-hidden border border-border/10 ${
+          themeKey === 'subtle' ? 'bg-secondary/30' : 'bg-transparent'
+        }`}
+      >
+        {/* Layout: assumption cards on sides, funnel in center */}
+        <div className="relative flex items-start">
+          {/* Left assumption cards */}
+          <div className="relative w-1/4 flex-shrink-0" style={{ height: `${svgHeight}px` }}>
+            {assumptionStages
+              .filter((_, i) => i % 2 === 0)
+              .map(({ stage, index }, cardIdx) => {
+                const topPercent = getStageVerticalPercent(index)
+                const animDelay = 0.15 + stages.length * 0.2 + 0.3 + cardIdx * 0.25
+                return (
+                  <motion.div
+                    key={index}
+                    className="absolute right-0 w-full pr-3"
+                    style={{ top: `${topPercent}%`, transform: 'translateY(-50%)' }}
+                    initial={{ opacity: 0, x: -20 }}
+                    animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: -20 }}
+                    transition={{ delay: animDelay, duration: 0.5, ease }}
+                  >
+                    <div className="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2.5">
+                      <p className="text-[10px] uppercase tracking-wider text-accent/50 font-semibold mb-1">
+                        Assumption
+                      </p>
+                      <p className="text-xs text-foreground/80 leading-relaxed font-medium">
+                        {stage.assumption}
+                      </p>
+                    </div>
+                  </motion.div>
+                )
+              })}
+          </div>
+
+          {/* Center funnel SVG */}
+          <div className="flex-1 flex-shrink-0">
+            <svg
+              viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+              className="w-full"
+              style={{ height: `${svgHeight}px` }}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              {/* Title */}
+              {title && (
+                <motion.text
+                  x={centerX}
+                  y={30}
+                  textAnchor="middle"
+                  fill="var(--foreground)"
+                  fontSize="18"
+                  fontWeight="700"
+                  fontFamily="system-ui, -apple-system, sans-serif"
+                  initial={{ opacity: 0 }}
+                  animate={isInView ? { opacity: 1 } : { opacity: 0 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  {title}
+                </motion.text>
+              )}
+
+              {/* Funnel stages */}
+              {stages.map((stage, i) => {
+                const y = getStageY(i)
+                const path = getStagePath(i)
+                const colors = getStageColors(stage)
+                const baseDelay = 0.15 + i * 0.2
+
+                return (
+                  <g key={i}>
+                    {/* Stroke draws in */}
+                    <motion.path
+                      d={path}
+                      fill="none"
+                      stroke={colors.stroke}
+                      strokeWidth={colors.strokeWidth}
+                      strokeOpacity={colors.strokeOpacity}
+                      strokeLinejoin="round"
+                      initial={{ pathLength: 0, opacity: 0 }}
+                      animate={isInView ? { pathLength: 1, opacity: 1 } : { pathLength: 0, opacity: 0 }}
+                      transition={{ delay: baseDelay, duration: 0.6, ease }}
+                    />
+
+                    {/* Fill */}
+                    <motion.path
+                      d={path}
+                      fill={colors.fill}
+                      fillOpacity={colors.fillOpacity}
+                      stroke="none"
+                      initial={{ opacity: 0 }}
+                      animate={isInView ? { opacity: 1 } : { opacity: 0 }}
+                      transition={{ delay: baseDelay + 0.4, duration: 0.3, ease }}
+                    />
+
+                    {/* Label */}
+                    <motion.text
+                      x={centerX}
+                      y={y + stageHeight / 2 + 5}
+                      textAnchor="middle"
+                      fill={colors.textFill}
+                      fillOpacity={colors.textOpacity}
+                      fontSize="13"
+                      fontWeight={stage.highlight ? '700' : '500'}
+                      fontFamily="system-ui, -apple-system, sans-serif"
+                      initial={{ opacity: 0 }}
+                      animate={isInView ? { opacity: 1 } : { opacity: 0 }}
+                      transition={{ delay: baseDelay + 0.5, duration: 0.3 }}
+                    >
+                      {stage.label}
+                    </motion.text>
+
+                    {/* Dashed connector lines to assumption cards */}
+                    {stage.assumption && (() => {
+                      const assumptionIdx = assumptionStages.findIndex(a => a.index === i)
+                      const isLeft = assumptionIdx % 2 === 0
+                      const stageWidth = getStageWidth(i)
+                      const edgeX = isLeft
+                        ? centerX - stageWidth / 2
+                        : centerX + stageWidth / 2
+                      const lineEndX = isLeft ? 0 : svgWidth
+                      const midY = y + stageHeight / 2
+                      const connectorDelay = 0.15 + stages.length * 0.2 + 0.15 + assumptionIdx * 0.25
+
+                      return (
+                        <motion.line
+                          x1={edgeX}
+                          y1={midY}
+                          x2={lineEndX}
+                          y2={midY}
+                          stroke="var(--accent)"
+                          strokeWidth="1"
+                          strokeDasharray="3,3"
+                          strokeOpacity={0.25}
+                          initial={{ pathLength: 0, opacity: 0 }}
+                          animate={isInView ? { pathLength: 1, opacity: 1 } : { pathLength: 0, opacity: 0 }}
+                          transition={{ delay: connectorDelay, duration: 0.4, ease }}
+                        />
+                      )
+                    })()}
+                  </g>
+                )
+              })}
+            </svg>
+          </div>
+
+          {/* Right assumption cards */}
+          <div className="relative w-1/4 flex-shrink-0" style={{ height: `${svgHeight}px` }}>
+            {assumptionStages
+              .filter((_, i) => i % 2 === 1)
+              .map(({ stage, index }, cardIdx) => {
+                const topPercent = getStageVerticalPercent(index)
+                const animDelay = 0.15 + stages.length * 0.2 + 0.3 + (cardIdx * 2 + 1) * 0.25
+                return (
+                  <motion.div
+                    key={index}
+                    className="absolute left-0 w-full pl-3"
+                    style={{ top: `${topPercent}%`, transform: 'translateY(-50%)' }}
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+                    transition={{ delay: animDelay, duration: 0.5, ease }}
+                  >
+                    <div className="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2.5">
+                      <p className="text-[10px] uppercase tracking-wider text-accent/50 font-semibold mb-1">
+                        Assumption
+                      </p>
+                      <p className="text-xs text-foreground/80 leading-relaxed font-medium">
+                        {stage.assumption}
+                      </p>
+                    </div>
+                  </motion.div>
+                )
+              })}
+          </div>
+        </div>
+
+        {/* Theme toggle */}
+        <div className="absolute bottom-3 right-3 flex items-center gap-1 bg-background/80 backdrop-blur-sm rounded-lg border border-border/20 p-1">
+          {(Object.keys(themeLabels) as ThemeKey[]).map((key) => (
+            <button
+              key={key}
+              onClick={() => setThemeKey(key)}
+              className={`px-2.5 py-1 text-xs rounded-md transition-colors ${
+                themeKey === key
+                  ? 'bg-foreground/10 text-foreground font-medium'
+                  : 'text-muted hover:text-foreground'
+              }`}
+            >
+              {themeLabels[key]}
+            </button>
+          ))}
+        </div>
+      </div>
+      {caption && (
+        <figcaption className="mt-2 text-sm text-muted text-center">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  )
+}

--- a/src/content/projects.ts
+++ b/src/content/projects.ts
@@ -25,7 +25,14 @@ export interface ListBlock {
   items: string[]
 }
 
-export type ContentBlock = MediaBlock | TextBlock | HeadingBlock | ListBlock
+export interface ComponentBlock {
+  type: 'component'
+  componentId: string
+  props?: Record<string, unknown>
+  caption?: string
+}
+
+export type ContentBlock = MediaBlock | TextBlock | HeadingBlock | ListBlock | ComponentBlock
 
 export interface Project {
   id: string
@@ -1090,20 +1097,81 @@ export const projects: Project[] = [
   },
   {
     id: 'seek-case-study-1',
-    title: 'SEEK Case Study 1',
-    description: 'Case study from SEEK — details coming soon.',
+    title: 'Iterating to Impact: SEEK Learning',
+    description: 'When the MVP didn\'t hit targets, we diagnosed the funnel, tested our assumptions with small changes, and shipped our way to the goal.',
     category: 'Product Design',
     year: '2024',
     companyId: 'seek',
-    tags: ['Product Design', 'Discovery', 'B2C'],
+    tags: ['Product Design', 'Experimentation', 'Conversion Optimisation', 'B2C'],
     content: [
-      { type: 'heading', level: 2, content: 'Coming Soon' },
-      { type: 'text', content: 'This case study is currently being written. Check back soon.' },
+      { type: 'heading', level: 2, content: 'The challenge' },
+      { type: 'text', content: 'SEEK Learning helps job seekers discover courses and connect with education providers. We released an MVP that gave users a way to browse courses by category, view course details, and submit a lead to the provider. The goal was clear: drive qualified leads to education partners.' },
+      { type: 'text', content: 'After launch, the numbers told a different story. Conversion through the funnel was well below target. Rather than redesigning from scratch, we needed to understand exactly where and why users were dropping off.' },
+
+      { type: 'heading', level: 2, content: 'Diagnosing the funnel' },
+      { type: 'text', content: 'We mapped the user journey as a conversion funnel with five stages, from first impression through to submitting a lead. By measuring drop-off between each stage, we could see where the biggest losses were happening.' },
+      {
+        type: 'component',
+        componentId: 'funnel-diagram',
+        props: {
+          title: 'MVP release',
+          stages: [
+            { label: 'Impressions', highlight: false },
+            { label: 'Find the right course (tabs)', highlight: true },
+            { label: 'Select a course', highlight: true },
+            { label: 'Course information', highlight: false },
+            { label: 'Lead/Link', highlight: true },
+          ],
+        },
+        caption: 'The MVP conversion funnel — highlighted stages showed the largest drop-offs',
+      },
+      { type: 'text', content: 'Three stages stood out with disproportionate drop-off. We formed hypotheses for each:' },
+
+      { type: 'heading', level: 2, content: 'Identifying assumptions' },
+      { type: 'text', content: 'For each problem area in the funnel, we identified a specific assumption about what was causing the drop-off. These became our test targets.' },
+      {
+        type: 'component',
+        componentId: 'funnel-diagram',
+        props: {
+          title: 'MVP release',
+          stages: [
+            { label: 'Impressions', highlight: false },
+            { label: 'Find the right course (tabs)', highlight: true, assumption: 'Too much friction to find a course' },
+            { label: 'Select a course', highlight: true, assumption: 'Missing design details' },
+            { label: 'Course information', highlight: false },
+            { label: 'Lead/Link', highlight: true, assumption: 'Too long to make a connection' },
+          ],
+        },
+        caption: 'Each drop-off point mapped to a specific assumption we could test',
+      },
+      {
+        type: 'list',
+        items: [
+          'Too much friction to find a course — the tab-based navigation required too many taps to discover relevant options',
+          'Missing design details — the course cards lacked the visual information needed to make a confident selection',
+          'Too long to make a connection — the path from interest to lead submission had unnecessary steps',
+        ],
+      },
+
+      { type: 'heading', level: 2, content: 'Testing with small changes' },
+      { type: 'text', content: 'Instead of a big redesign, we tested each assumption independently with the smallest change that could validate or invalidate it. This let us isolate what was actually driving the problem and avoid wasting effort on the wrong solution.' },
+      { type: 'text', content: 'Each experiment was scoped to a single funnel stage and measured against the specific drop-off rate at that point. When a change moved the needle, we kept it and moved to the next assumption.' },
+
+      { type: 'heading', level: 2, content: 'Outcome' },
+      { type: 'text', content: 'By working through the funnel systematically — one assumption at a time — we improved conversion at each stage and ultimately hit our lead generation target. The approach proved that disciplined experimentation on a live product can be more effective than redesigning from first principles.' },
     ],
     chatContext: {
-      description: 'A case study from SEEK - details coming soon',
-      suggestedQuestions: ['What was this project about?'],
-      followUpQuestions: ['What was the impact?'],
+      description: 'A case study about iterating on SEEK Learning\'s course discovery funnel. After the MVP underperformed, the team diagnosed drop-offs at three stages (finding courses, selecting courses, and submitting leads), formed hypotheses for each, and ran targeted experiments to improve conversion.',
+      suggestedQuestions: [
+        'What was the MVP and why didn\'t it work?',
+        'How did you decide what to test first?',
+        'What were the three main assumptions?',
+      ],
+      followUpQuestions: [
+        'How did you measure success for each experiment?',
+        'What was the biggest single improvement?',
+        'How long did the iteration cycle take?',
+      ],
     },
   },
   {


### PR DESCRIPTION
## Summary
- Replace placeholder SEEK case study with full iteration story (diagnosing the funnel, testing assumptions, shipping improvements)
- Add interactive `FunnelDiagram` component with animated stages, accent theming, and assumption cards
- Add `component` block type to content system so case studies can embed React components inline

## Test plan
- [ ] Visit `/projects/seek-case-study-1` — verify case study content renders
- [ ] Check funnel diagram animates in on scroll
- [ ] Hover funnel stages to verify accent highlight
- [ ] Toggle theme variants (Accent/Subtle/Minimal/Outline)
- [ ] Switch to Visuals tab — verify funnel diagram appears in gallery view

🤖 Generated with [Claude Code](https://claude.com/claude-code)