### PR TITLE
Fix white rectangle behind FAB chat button

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -166,7 +166,7 @@ export default function ContactPage() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.8 }}
                 onClick={() => setChatOpen(true)}
-                className="fixed bottom-6 right-6 z-50 shadow-lg hover:scale-110 transition-all"
+                className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg hover:scale-110 transition-all"
               >
                 <Facehash name="GarethLLM" size={48} showInitial enableBlink interactive={false} intensity3d="subtle" style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 60%, var(--background))', borderRadius: '9999px' }} />
               </motion.button>

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -216,7 +216,7 @@ export default function CVPage() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.8 }}
                 onClick={() => setChatOpen(true)}
-                className="fixed bottom-6 right-6 z-50 shadow-lg hover:scale-110 transition-all"
+                className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg hover:scale-110 transition-all"
               >
                 <Facehash name="GarethLLM" size={48} showInitial enableBlink interactive={false} intensity3d="subtle" style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 60%, var(--background))', borderRadius: '9999px' }} />
               </motion.button>

--- a/src/app/how-i-work/page.tsx
+++ b/src/app/how-i-work/page.tsx
@@ -227,7 +227,7 @@ export default function HowIWorkPage() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.8 }}
                 onClick={() => setChatOpen(true)}
-                className="fixed bottom-6 right-6 z-50 shadow-lg hover:scale-110 transition-all"
+                className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg hover:scale-110 transition-all"
               >
                 <Facehash name="GarethLLM" size={48} showInitial enableBlink interactive={false} intensity3d="subtle" style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 60%, var(--background))', borderRadius: '9999px' }} />
               </motion.button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -752,7 +752,7 @@ export default function Home() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.8 }}
                 onClick={() => setChatOpen(true)}
-                className="fixed bottom-6 right-6 z-50 shadow-lg hover:scale-110 transition-all"
+                className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg hover:scale-110 transition-all"
               >
                 <Facehash name="GarethLLM" size={48} showInitial enableBlink interactive={false} intensity3d="subtle" style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 60%, var(--background))', borderRadius: '9999px' }} />
               </motion.button>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -472,7 +472,7 @@ Write 2-3 short paragraphs tailored to what a ${tldrLength} would want to know. 
           ) : (
             <button
               onClick={() => setChatOpen(true)}
-              className="fixed bottom-6 right-6 z-50 shadow-lg hover:scale-110 transition-all"
+              className="fixed bottom-6 right-6 z-50 rounded-full shadow-lg hover:scale-110 transition-all"
             >
               <Facehash name="GarethLLM" size={48} showInitial enableBlink interactive={false} intensity3d="subtle" style={{ backgroundColor: 'color-mix(in srgb, var(--accent) 60%, var(--background))', borderRadius: '9999px' }} />
             </button>

--- a/src/content/changelog.ts
+++ b/src/content/changelog.ts
@@ -14,6 +14,18 @@ export interface ChangelogEntry {
 // Changelog entries - newest first
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '1.16.1',
+    date: '2026-03-21',
+    title: 'Fix FAB White Rectangle',
+    description: 'Fixed the floating chat avatar button showing a white rectangle behind it in light mode.',
+    changes: [
+      'Added rounded-full to the FAB button element so the shadow and background clip to a circle',
+      'Applied fix across all pages (home, contact, how-i-work, cv, projects)',
+    ],
+    aiTools: ['Claude Code'],
+    branch: 'GChainey/fix-fab-background',
+  },
+  {
     version: '1.16.0',
     date: '2026-02-27',
     title: 'Animated Accent SVG Cards',


### PR DESCRIPTION
## Summary
- Adds `rounded-full` to the floating action button on all pages so the shadow and background clip to a circle, removing a visible white rectangle in light mode
- The Facehash avatar inside already had `borderRadius: 9999px`, but the parent `<button>` was rectangular, causing the artifact
- Applied consistently across home, contact, how-i-work, cv, and project pages
- Added changelog entry (v1.16.1)

## Test plan
- [ ] Open the site in light mode and verify the FAB has no white rectangle behind it
- [ ] Check all pages: home, contact, how-i-work, cv, and any project page
- [ ] Verify the circular shadow looks correct in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)